### PR TITLE
Remove VAT calculation from cart and orders

### DIFF
--- a/MachMangsho/src/pages/Cart.jsx
+++ b/MachMangsho/src/pages/Cart.jsx
@@ -147,11 +147,8 @@ const Cart = () => {
                     <p className="flex justify-between">
                         <span style={{ color: '#c9595a' }}>Delivery Charge</span><span style={{ color: '#c9595a' }}>{curency}40</span>
                     </p>
-                    <p className="flex justify-between">
-                        <span>Tax (2%)</span><span>{curency}{getCartAmount() * 2 /100}</span>
-                    </p>
                     <p className="flex justify-between text-lg font-medium mt-3">
-                        <span style={{ color: '#c9595a' }}>Total Amount:</span><span style={{ color: '#c9595a' }}>{curency}{getCartAmount() + getCartAmount() * 2 /100 + 40}</span>
+                        <span style={{ color: '#c9595a' }}>Total Amount:</span><span style={{ color: '#c9595a' }}>{curency}{getCartAmount() + 40}</span>
                     </p>
                 </div>
 

--- a/MachMangsho/src/pages/MyOrders.jsx
+++ b/MachMangsho/src/pages/MyOrders.jsx
@@ -30,13 +30,11 @@ const MyOrders = () => {
                     <span className="text-black font-medium">Payment : {order.paymentType}</span>
                     {(() => {
   const subtotal = order.items.reduce((acc, item) => acc + ((item.product.offerPrice ?? item.product.price) * Number(item.quantity ?? item.quatity ?? 1)), 0);
-  const vat = +(subtotal * 0.02).toFixed(2);
   const deliveryCharge = 40;
-  const total = subtotal + vat + deliveryCharge;
+  const total = subtotal + deliveryCharge;
   return (
     <span className="text-[#c9595a] font-medium flex flex-col items-end gap-0.5 text-right text-[17px]">
       <span className="text-[#c9595a] font-medium">Subtotal: {currency}{subtotal}</span>
-      <span className="text-[#c9595a] font-medium">VAT (2%): {currency}{vat}</span>
       <span className="text-[#c9595a] font-medium">Delivery Charge: {currency}{deliveryCharge}</span>
       <span className="text-[#c9595a] font-medium">Total Amount: {currency}{total}</span>
     </span>


### PR DESCRIPTION
VAT (2%) calculation and display have been removed from both the Cart and MyOrders pages. Total amount now only includes subtotal and delivery charge.