### PR TITLE
Update cookie sameSite policy to 'Lax' in production

### DIFF
--- a/MachMangsho/server/controllers/UserController.js
+++ b/MachMangsho/server/controllers/UserController.js
@@ -67,7 +67,7 @@ export const register = async (req, res) => {
         res.cookie('token', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite:  process.env.NODE_ENV === 'production' ? 'None' : 'strict', //CSRF protection
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
 
@@ -103,7 +103,7 @@ export const login = async (req, res) => {
         res.cookie('token', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite:  process.env.NODE_ENV === 'production' ? 'None' : 'strict', //CSRF protection
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
 
@@ -140,7 +140,7 @@ export  const logout = async(req, res) => {
         res.clearCookie('token', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'strict'
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict'
         });
 
         return res.json({ success: true, message: "Logged out successfully" });

--- a/MachMangsho/server/controllers/sellerController.js
+++ b/MachMangsho/server/controllers/sellerController.js
@@ -21,7 +21,7 @@ export const sellerLogin =  async (req, res) => {
         res.cookie('sellerToken', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite:  process.env.NODE_ENV === 'production' ? 'None' : 'strict', //CSRF protection
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
 
@@ -58,7 +58,7 @@ export  const sellerLogout = async(req, res) => {
         res.cookie('sellerToken', '', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'strict',
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict',
             path: '/',
             maxAge: 0,
             expires: new Date(0),
@@ -68,7 +68,7 @@ export  const sellerLogout = async(req, res) => {
         res.clearCookie('sellerToken', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'strict',
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict',
             path: '/',
         });
 

--- a/MachMangsho/server/controllers/userController.js
+++ b/MachMangsho/server/controllers/userController.js
@@ -67,7 +67,7 @@ export const register = async (req, res) => {
         res.cookie('token', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite:  process.env.NODE_ENV === 'production' ? 'None' : 'strict', //CSRF protection
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
 
@@ -103,7 +103,7 @@ export const login = async (req, res) => {
         res.cookie('token', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite:  process.env.NODE_ENV === 'production' ? 'None' : 'strict', //CSRF protection
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
 
@@ -140,7 +140,7 @@ export  const logout = async(req, res) => {
         res.clearCookie('token', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'strict'
+            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict'
         });
 
         return res.json({ success: true, message: "Logged out successfully" });


### PR DESCRIPTION
Changed the sameSite attribute for authentication cookies from 'None' to 'Lax' when in production environment in both user and seller controllers. This enhances security by providing better CSRF protection and aligns with recommended cookie practices.