### PR TITLE
Set SameSite=None for cookies in production

### DIFF
--- a/MachMangsho/server/controllers/UserController.js
+++ b/MachMangsho/server/controllers/UserController.js
@@ -67,7 +67,8 @@ export const register = async (req, res) => {
         res.cookie('token', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
+            // For separate frontend/backend domains on Vercel, SameSite must be 'None' in production
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
@@ -104,7 +105,8 @@ export const login = async (req, res) => {
         res.cookie('token', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
+            // For separate frontend/backend domains on Vercel, SameSite must be 'None' in production
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
@@ -143,7 +145,7 @@ export  const logout = async(req, res) => {
         res.cookie('token', '', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict',
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
             maxAge: 0,
             expires: new Date(0)
@@ -153,7 +155,7 @@ export  const logout = async(req, res) => {
         res.clearCookie('token', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict',
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/'
         });
 

--- a/MachMangsho/server/controllers/sellerController.js
+++ b/MachMangsho/server/controllers/sellerController.js
@@ -21,7 +21,8 @@ export const sellerLogin =  async (req, res) => {
         res.cookie('sellerToken', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
+            // For separate frontend/backend domains on Vercel, SameSite must be 'None' in production
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
@@ -59,7 +60,7 @@ export  const sellerLogout = async(req, res) => {
         res.cookie('sellerToken', '', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict',
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
             maxAge: 0,
             expires: new Date(0),
@@ -69,7 +70,7 @@ export  const sellerLogout = async(req, res) => {
         res.clearCookie('sellerToken', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict',
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
         });
 

--- a/MachMangsho/server/controllers/userController.js
+++ b/MachMangsho/server/controllers/userController.js
@@ -67,7 +67,8 @@ export const register = async (req, res) => {
         res.cookie('token', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
+            // For separate frontend/backend domains on Vercel, SameSite must be 'None' in production
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
@@ -104,7 +105,8 @@ export const login = async (req, res) => {
         res.cookie('token', token, {
             httpOnly: true, // Prevents client-side JavaScript from accessing the cookie
             secure: process.env.NODE_ENV === 'production', // Use secure cookies in production
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict', // More secure for production
+            // For separate frontend/backend domains on Vercel, SameSite must be 'None' in production
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
@@ -143,7 +145,7 @@ export  const logout = async(req, res) => {
         res.cookie('token', '', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict',
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
             maxAge: 0,
             expires: new Date(0)
@@ -153,7 +155,7 @@ export  const logout = async(req, res) => {
         res.clearCookie('token', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'Lax' : 'strict',
+            sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/'
         });
 


### PR DESCRIPTION
Updated cookie settings in user and seller controllers to use SameSite=None instead of Lax when in production. This change is required for cross-domain authentication scenarios, such as when frontend and backend are hosted on separate domains (e.g., on Vercel).