### PR TITLE
Clear legacy cookies and update logout routes

### DIFF
--- a/MachMangsho/server/controllers/UserController.js
+++ b/MachMangsho/server/controllers/UserController.js
@@ -72,6 +72,9 @@ export const register = async (req, res) => {
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
+    // Proactively clear any legacy path-scoped cookies that may linger from older deployments
+    res.clearCookie('token', { path: '/api/user', secure: process.env.NODE_ENV === 'production' });
+    res.clearCookie('token', { path: '/api', secure: process.env.NODE_ENV === 'production' });
 
         return res.json({success: true, user: { email: user.email, name: user.name } });
     } catch (error) {
@@ -110,6 +113,9 @@ export const login = async (req, res) => {
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
+    // Proactively clear any legacy path-scoped cookies that may linger from older deployments
+    res.clearCookie('token', { path: '/api/user', secure: process.env.NODE_ENV === 'production' });
+    res.clearCookie('token', { path: '/api', secure: process.env.NODE_ENV === 'production' });
 
     return res.json({ success: true, token, user: { email: user.email, name: user.name } });
     } catch (error) {
@@ -151,13 +157,17 @@ export  const logout = async(req, res) => {
             expires: new Date(0)
         });
 
-        // Clear cookie with matching attributes
+    // Clear cookie with matching attributes
         res.clearCookie('token', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
             sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/'
         });
+
+    // Also clear potential legacy path-scoped cookies from older versions
+    res.clearCookie('token', { path: '/api/user', secure: process.env.NODE_ENV === 'production' });
+    res.clearCookie('token', { path: '/api', secure: process.env.NODE_ENV === 'production' });
 
         return res.json({ success: true, message: "Logged out successfully" });
     } catch (error) {

--- a/MachMangsho/server/controllers/sellerController.js
+++ b/MachMangsho/server/controllers/sellerController.js
@@ -26,6 +26,9 @@ export const sellerLogin =  async (req, res) => {
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
+    // Proactively clear any legacy path-scoped cookies
+    res.clearCookie('sellerToken', { path: '/api/seller', secure: process.env.NODE_ENV === 'production' });
+    res.clearCookie('sellerToken', { path: '/api', secure: process.env.NODE_ENV === 'production' });
 
         return res.status(200).json({ success: true, message: 'Login successful' });
     }else{
@@ -73,6 +76,10 @@ export  const sellerLogout = async(req, res) => {
             sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/',
         });
+
+    // Also clear potential legacy path-scoped cookies
+    res.clearCookie('sellerToken', { path: '/api/seller', secure: process.env.NODE_ENV === 'production' });
+    res.clearCookie('sellerToken', { path: '/api', secure: process.env.NODE_ENV === 'production' });
 
         return res.json({ success: true, message: "Logged out successfully" });
     } catch (error) {

--- a/MachMangsho/server/controllers/userController.js
+++ b/MachMangsho/server/controllers/userController.js
@@ -72,6 +72,9 @@ export const register = async (req, res) => {
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
+    // Proactively clear any legacy path-scoped cookies that may linger from older deployments
+    res.clearCookie('token', { path: '/api/user', secure: process.env.NODE_ENV === 'production' });
+    res.clearCookie('token', { path: '/api', secure: process.env.NODE_ENV === 'production' });
 
         return res.json({success: true, user: { email: user.email, name: user.name } });
     } catch (error) {
@@ -110,6 +113,9 @@ export const login = async (req, res) => {
             path: '/',
             maxAge: 7 * 24 * 60 * 60 * 1000 // 7 days
         });
+    // Proactively clear any legacy path-scoped cookies that may linger from older deployments
+    res.clearCookie('token', { path: '/api/user', secure: process.env.NODE_ENV === 'production' });
+    res.clearCookie('token', { path: '/api', secure: process.env.NODE_ENV === 'production' });
 
     return res.json({ success: true, token, user: { email: user.email, name: user.name } });
     } catch (error) {
@@ -151,13 +157,17 @@ export  const logout = async(req, res) => {
             expires: new Date(0)
         });
 
-        // Clear cookie with matching attributes
+    // Clear cookie with matching attributes
         res.clearCookie('token', {
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
             sameSite: process.env.NODE_ENV === 'production' ? 'None' : 'Lax',
             path: '/'
         });
+
+    // Also clear potential legacy path-scoped cookies from older versions
+    res.clearCookie('token', { path: '/api/user', secure: process.env.NODE_ENV === 'production' });
+    res.clearCookie('token', { path: '/api', secure: process.env.NODE_ENV === 'production' });
 
         return res.json({ success: true, message: "Logged out successfully" });
     } catch (error) {

--- a/MachMangsho/server/routes/sellerRoute.js
+++ b/MachMangsho/server/routes/sellerRoute.js
@@ -5,7 +5,8 @@ const sellerRouter = express.Router();
 
 sellerRouter.post('/login', sellerLogin);
 sellerRouter.get('/is-auth',authSeller, isSellerAuth);
-sellerRouter.post('/logout', authSeller, sellerLogout);
+// Allow logout without auth so stale/expired cookies can always be cleared
+sellerRouter.post('/logout', sellerLogout);
 
 // Export both named and default to avoid ESM import issues
 export { sellerRouter };

--- a/MachMangsho/server/routes/userRoute.js
+++ b/MachMangsho/server/routes/userRoute.js
@@ -6,7 +6,10 @@ const userRouter = express.Router();
 userRouter.post('/register', register);
 userRouter.post('/login', login);
 userRouter.get('/is-auth', authUser, isAuth);
-userRouter.get('/logout', authUser, logout);
+// Allow logout without auth so stale/expired cookies can always be cleared
+userRouter.get('/logout', logout);
+// Optional: support POST logout as well for flexibility
+userRouter.post('/logout', logout);
 userRouter.post('/forgot-password', forgotPassword);
 userRouter.post('/reset-password', resetPassword);
 


### PR DESCRIPTION
Proactively clear legacy path-scoped cookies for user and seller authentication in controller methods to prevent lingering tokens from older deployments. Updated user and seller logout routes to allow logout without authentication, ensuring stale or expired cookies can always be cleared. Added support for POST /logout on user routes for flexibility.