### PR TITLE
Enforce max quantity of 10 per product in cart and orders

### DIFF
--- a/MachMangsho/src/context/AppContext.jsx
+++ b/MachMangsho/src/context/AppContext.jsx
@@ -82,23 +82,29 @@ export const AppContextProvider = ({ children }) => {
 
     // ADD Products to cart
     const addToCart = (itemID) => {
-        let cartData = structuredClone(cartItems);
-        if(cartData[itemID]){
-            cartData[itemID] += 1;
-        }else{
-            cartData[itemID] = 1;
+        const current = Number(cartItems[itemID] || 0);
+        if (current >= 10) {
+            toast.error('Maximum 10 items can be added at once');
+            return;
         }
-
+        const cartData = structuredClone(cartItems);
+        cartData[itemID] = current + 1;
         setCartItems(cartData);
         toast.success("Item added to cart");
     }
 
     const updateCartItem = (itemID, quantity) => {
-        let cartData = structuredClone(cartItems);
-        cartData[itemID] = quantity;
+        const q = Math.floor(Number(quantity));
+        if (!Number.isFinite(q)) return; // ignore bad input
+        const next = Math.max(1, Math.min(10, q));
+        const cartData = structuredClone(cartItems);
+        cartData[itemID] = next;
         setCartItems(cartData);
-        toast.success("Cart updated successfully");
-    
+        if (q > 10) {
+            toast.error('Maximum 10 items can be added at once');
+        } else {
+            toast.success("Cart updated successfully");
+        }
     }
 
     // remove item from cart

--- a/MachMangsho/src/pages/Cart.jsx
+++ b/MachMangsho/src/pages/Cart.jsx
@@ -143,12 +143,14 @@ const Cart = () => {
                                     <p>Weight: <span>{product.weight || "N/A"}</span></p>
                                     <div className='flex items-center'>
                                         <p>Qty:</p>
-                                        <select onChange={e=> updateCartItem(product._id, Number(e.target.value)) } value={cartItems[product._id]}
-                                         className='outline-none'>
-                                            {Array(cartItems[product._id] > 9 ? cartItems[product._id] : 9).fill('').map((_, index) => (
-                                                <option key={index} value={index + 1}>{index + 1}</option>
-                                            ))}
-                                        </select>
+                                                                                <select
+                                                                                    onChange={(e)=> updateCartItem(product._id, Number(e.target.value)) }
+                                                                                    value={Math.min(10, Math.max(1, cartItems[product._id]))}
+                                                                                    className='outline-none'>
+                                                                                        {Array(10).fill('').map((_, index) => (
+                                                                                                <option key={index} value={index + 1}>{index + 1}</option>
+                                                                                        ))}
+                                                                                </select>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Added validation on both frontend and backend to restrict product quantity to a maximum of 10 per item in the cart and during order placement. Updated cart UI to only allow selection of quantities between 1 and 10, and improved error handling and user feedback for quantity limits.